### PR TITLE
Exercise モデルの実装

### DIFF
--- a/.annotaterb.yml
+++ b/.annotaterb.yml
@@ -1,0 +1,64 @@
+---
+:position: before
+:position_in_additional_file_patterns: before
+:position_in_class: before
+:position_in_factory: before
+:position_in_fixture: before
+:position_in_routes: before
+:position_in_serializer: before
+:position_in_test: before
+:classified_sort: true
+:exclude_controllers: true
+:exclude_factories: false
+:exclude_fixtures: false
+:exclude_helpers: true
+:exclude_scaffolds: true
+:exclude_serializers: false
+:exclude_sti_subclasses: false
+:exclude_tests: false
+:force: false
+:format_markdown: false
+:format_rdoc: false
+:format_yard: false
+:frozen: false
+:grouped_polymorphic: false
+:ignore_model_sub_dir: false
+:ignore_unknown_models: false
+:include_version: false
+:show_check_constraints: false
+:show_complete_foreign_keys: false
+:show_foreign_keys: true
+:show_indexes: true
+:show_indexes_include: false
+:simple_indexes: false
+:sort: false
+:timestamp: false
+:trace: false
+:with_comment: true
+:with_column_comments: true
+:with_table_comments: true
+:position_of_column_comment: :with_name
+:active_admin: false
+:command:
+:debug: false
+:hide_default_column_types: ''
+:hide_limit_column_types: ''
+:timestamp_columns:
+- created_at
+- updated_at
+:ignore_columns:
+:ignore_routes:
+:models: true
+:routes: false
+:skip_on_db_migrate: false
+:target_action: :do_annotations
+:wrapper:
+:wrapper_close:
+:wrapper_open:
+:classes_default_to_s: []
+:additional_file_patterns: []
+:model_dir:
+- app/models
+:require: []
+:root_dir:
+- ''

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ docker-compose up --build
 
 - **bundle install は手動実行が必要**: Gemfile を編集した後は、Dev Container 内のターミナルで `bundle install` を実行してください
 - Claude Code から実行した bundle install は Dev Container 内に反映されません
+- **テスト実行は手動で行う**: Claude Code はテスト実行を試行しない。テストは開発者が Dev Container 内で手動実行する
 
 ### テスト実行
 

--- a/Gemfile
+++ b/Gemfile
@@ -58,4 +58,5 @@ end
 group :development do
   # Git hooks manager
   gem "lefthook", require: false
+  gem "annotaterb"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,9 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
+    annotaterb (4.19.0)
+      activerecord (>= 6.0.0)
+      activesupport (>= 6.0.0)
     ast (2.4.3)
     base64 (0.3.0)
     bcrypt_pbkdf (1.1.1)
@@ -304,6 +307,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  annotaterb
   bootsnap
   brakeman
   debug

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -22,14 +22,5 @@ class Exercise < ApplicationRecord
   validates :name, presence: true, uniqueness: true, length: { maximum: 255 }
   validates :exercise_type, presence: true
   validates :laterality, presence: true, if: :strength?
-
-  validate :laterality_must_be_nil_for_cardio
-
-  private
-
-  def laterality_must_be_nil_for_cardio
-    if cardio? && laterality.present?
-      errors.add(:laterality, "有酸素運動の場合、実施形態は設定できません")
-    end
-  end
+  validates :laterality, absence: true, if: :cardio?
 end

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: exercises
+#
+#  id            :bigint           not null, primary key
+#  exercise_type :integer
+#  laterality    :integer
+#  memo          :text(65535)
+#  name          :string(255)
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
+# Indexes
+#
+#  index_exercises_on_exercise_type  (exercise_type)
+#  index_exercises_on_name           (name) UNIQUE
+#
 class Exercise < ApplicationRecord
   enum :exercise_type, { strength: 0, cardio: 1 }
   enum :laterality, { bilateral: 0, unilateral: 1 }

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -22,5 +22,5 @@ class Exercise < ApplicationRecord
   validates :name, presence: true, uniqueness: true, length: { maximum: 255 }
   validates :exercise_type, presence: true
   validates :laterality, presence: true, if: :strength?
-  validates :laterality, absence: true, if: :cardio?
+  validates :laterality, absence: { message: "有酸素運動の場合、実施形態は設定できません" }, if: :cardio?
 end

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -1,0 +1,18 @@
+class Exercise < ApplicationRecord
+  enum :exercise_type, { strength: 0, cardio: 1 }
+  enum :laterality, { bilateral: 0, unilateral: 1 }
+
+  validates :name, presence: true, uniqueness: true, length: { maximum: 255 }
+  validates :exercise_type, presence: true
+  validates :laterality, presence: true, if: :strength?
+
+  validate :laterality_must_be_nil_for_cardio
+
+  private
+
+  def laterality_must_be_nil_for_cardio
+    if cardio? && laterality.present?
+      errors.add(:laterality, "有酸素運動の場合、実施形態は設定できません")
+    end
+  end
+end

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -3,10 +3,10 @@
 # Table name: exercises
 #
 #  id            :bigint           not null, primary key
-#  exercise_type :integer
+#  exercise_type :integer          not null
 #  laterality    :integer
 #  memo          :text(65535)
-#  name          :string(255)
+#  name          :string(255)      not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id           :bigint           not null, primary key
+#  email        :string(255)
+#  firebase_uid :string(255)
+#  image_url    :string(255)
+#  name         :string(255)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_firebase_uid  (firebase_uid) UNIQUE
+#
 class User < ApplicationRecord
   # Firebase認証用のバリデーション
   validates :firebase_uid, presence: true, uniqueness: true

--- a/db/migrate/20250908074249_create_exercises.rb
+++ b/db/migrate/20250908074249_create_exercises.rb
@@ -1,8 +1,8 @@
 class CreateExercises < ActiveRecord::Migration[8.0]
   def change
     create_table :exercises do |t|
-      t.string :name
-      t.integer :exercise_type
+      t.string :name, null: false
+      t.integer :exercise_type, null: false
       t.integer :laterality
       t.text :memo
 

--- a/db/migrate/20250908074249_create_exercises.rb
+++ b/db/migrate/20250908074249_create_exercises.rb
@@ -1,0 +1,14 @@
+class CreateExercises < ActiveRecord::Migration[8.0]
+  def change
+    create_table :exercises do |t|
+      t.string :name
+      t.integer :exercise_type
+      t.integer :laterality
+      t.text :memo
+
+      t.timestamps
+    end
+    add_index :exercises, :name, unique: true
+    add_index :exercises, :exercise_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,8 +12,8 @@
 
 ActiveRecord::Schema[8.0].define(version: 2025_09_08_074249) do
   create_table "exercises", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
-    t.string "name"
-    t.integer "exercise_type"
+    t.string "name", null: false
+    t.integer "exercise_type", null: false
     t.integer "laterality"
     t.text "memo"
     t.datetime "created_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_06_144544) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_08_074249) do
+  create_table "exercises", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+    t.string "name"
+    t.integer "exercise_type"
+    t.integer "laterality"
+    t.text "memo"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["exercise_type"], name: "index_exercises_on_exercise_type"
+    t.index ["name"], name: "index_exercises_on_name", unique: true
+  end
+
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.string "firebase_uid"
     t.string "email"

--- a/docs/データベース設計.md
+++ b/docs/データベース設計.md
@@ -22,10 +22,8 @@ erDiagram
     exercises {
         bigint id PK
         string name UK "種目名"
-        boolean is_dumbbell "ダンベル種目フラグ"
-        boolean is_unilateral "片方ずつ実施する種目フラグ"
-        boolean is_bodyweight "自重種目フラグ"
-        boolean is_cardio "有酸素運動フラグ"
+        integer exercise_type "運動タイプ"
+        integer laterality "実施形態"
         text memo "メモ"
         datetime created_at
         datetime updated_at
@@ -92,17 +90,31 @@ erDiagram
 
 ### exercises（種目マスタ）
 
-| カラム名      | 型           | NULL | デフォルト        | 説明                       |
-| ------------- | ------------ | ---- | ----------------- | -------------------------- |
-| id            | bigint       | NO   | AUTO_INCREMENT    | 主キー                     |
-| name          | varchar(255) | NO   | -                 | 種目名                     |
-| is_dumbbell   | boolean      | NO   | false             | ダンベル種目フラグ         |
-| is_unilateral | boolean      | NO   | false             | 片方ずつ実施する種目フラグ |
-| is_bodyweight | boolean      | NO   | false             | 自重種目フラグ             |
-| is_cardio     | boolean      | NO   | false             | 有酸素運動フラグ           |
-| memo          | text         | YES  | NULL              | メモ                       |
-| created_at    | datetime     | NO   | CURRENT_TIMESTAMP | 作成日時                   |
-| updated_at    | datetime     | NO   | CURRENT_TIMESTAMP | 更新日時                   |
+| カラム名       | 型           | NULL | デフォルト        | 説明                          |
+| -------------- | ------------ | ---- | ----------------- | ----------------------------- |
+| id             | bigint       | NO   | AUTO_INCREMENT    | 主キー                        |
+| name           | varchar(255) | NO   | -                 | 種目名                        |
+| exercise_type  | integer      | NO   | -                 | 運動タイプ（enum: 0-1）       |
+| laterality     | integer      | YES  | NULL              | 実施形態（enum: 0-1）         |
+| memo           | text         | YES  | NULL              | メモ                          |
+| created_at     | datetime     | NO   | CURRENT_TIMESTAMP | 作成日時                      |
+| updated_at     | datetime     | NO   | CURRENT_TIMESTAMP | 更新日時                      |
+
+#### exercise_type の値
+
+| 値 | 名称     | 説明           |
+|----|---------|---------------|
+| 0  | strength| 筋力トレーニング |
+| 1  | cardio  | 有酸素運動     |
+
+#### laterality の値
+
+| 値 | 名称       | 説明           |
+|----|-----------|---------------|
+| 0  | bilateral | 両側同時実施   |
+| 1  | unilateral| 片側ずつ実施   |
+
+※ 有酸素運動（cardio）の場合は NULL
 
 ### workouts（ワークアウト）
 

--- a/docs/実装方針.md
+++ b/docs/実装方針.md
@@ -296,14 +296,14 @@ end
 
   ```ruby
   # Gemfile
-  gem 'annotate', group: :development
+  gem 'annotaterb', group: :development
 
   # 実行コマンド
-  bundle exec annotate --models
+  bundle exec annotaterb models
 
   # 自動実行設定（マイグレーション後に自動更新）
   # lib/tasks/auto_annotate_models.rake が生成される
-  bundle exec rails g annotate:install
+  bundle exec rails g annotaterb:install
   ```
 
 ### 開発環境推奨

--- a/docs/開発フロー.md
+++ b/docs/開発フロー.md
@@ -134,7 +134,7 @@ bundle exec rubocop -A
 #### 5-3. Annotate 実行
 
 ```bash
-bundle exec annotate --models
+bundle exec annotaterb models
 ```
 
 ### 6. コミット・プッシュ

--- a/lib/tasks/annotate_rb.rake
+++ b/lib/tasks/annotate_rb.rake
@@ -1,0 +1,8 @@
+# This rake task was added by annotate_rb gem.
+
+# Can set `ANNOTATERB_SKIP_ON_DB_TASKS` to be anything to skip this
+if Rails.env.development? && ENV["ANNOTATERB_SKIP_ON_DB_TASKS"].nil?
+  require "annotate_rb"
+
+  AnnotateRb::Core.load_rake_tasks
+end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,5 +1,21 @@
 # テスト用のユーザーデータ
 
+# == Schema Information
+#
+# Table name: users
+#
+#  id           :bigint           not null, primary key
+#  email        :string(255)
+#  firebase_uid :string(255)
+#  image_url    :string(255)
+#  name         :string(255)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_firebase_uid  (firebase_uid) UNIQUE
+#
 one:
   firebase_uid: "firebase_uid_123"
   email: "test@example.com"

--- a/test/models/exercise_test.rb
+++ b/test/models/exercise_test.rb
@@ -85,13 +85,14 @@ class ExerciseTest < ActiveSupport::TestCase
     valid_exercise_types = %w[strength cardio]
 
     valid_exercise_types.each do |exercise_type|
-      @exercise.exercise_type = exercise_type
+      exercise = @exercise.dup
+      exercise.exercise_type = exercise_type
       if exercise_type == "cardio"
-        @exercise.laterality = nil
+        exercise.laterality = nil
       else
-        @exercise.laterality = "bilateral"
+        exercise.laterality = "bilateral"
       end
-      assert @exercise.valid?, "#{exercise_type}は有効な値であるべき"
+      assert exercise.valid?, "#{exercise_type}は有効な値であるべき"
     end
   end
 
@@ -99,8 +100,9 @@ class ExerciseTest < ActiveSupport::TestCase
     valid_lateralities = %w[bilateral unilateral]
 
     valid_lateralities.each do |laterality|
-      @exercise.laterality = laterality
-      assert @exercise.valid?, "#{laterality}は有効な値であるべき"
+      exercise = @exercise.dup
+      exercise.laterality = laterality
+      assert exercise.valid?, "#{laterality}は有効な値であるべき"
     end
   end
 

--- a/test/models/exercise_test.rb
+++ b/test/models/exercise_test.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: exercises
+#
+#  id            :bigint           not null, primary key
+#  exercise_type :integer
+#  laterality    :integer
+#  memo          :text(65535)
+#  name          :string(255)
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
+# Indexes
+#
+#  index_exercises_on_exercise_type  (exercise_type)
+#  index_exercises_on_name           (name) UNIQUE
+#
 require "test_helper"
 
 class ExerciseTest < ActiveSupport::TestCase

--- a/test/models/exercise_test.rb
+++ b/test/models/exercise_test.rb
@@ -1,0 +1,133 @@
+require "test_helper"
+
+class ExerciseTest < ActiveSupport::TestCase
+  def setup
+    @exercise = Exercise.new(
+      name: "ベンチプレス",
+      exercise_type: "strength",
+      laterality: "bilateral",
+      memo: "胸部の基本種目"
+    )
+  end
+
+  test "有効なエクササイズを作成できる" do
+    assert @exercise.valid?
+  end
+
+  test "nameが必須である" do
+    @exercise.name = ""
+    assert_not @exercise.valid?
+    assert_includes @exercise.errors[:name], "を入力してください"
+  end
+
+  test "nameが一意である" do
+    @exercise.save!
+    duplicate_exercise = @exercise.dup
+    assert_not duplicate_exercise.valid?
+    assert_includes duplicate_exercise.errors[:name], "はすでに存在します"
+  end
+
+  test "nameの最大文字数は255文字である" do
+    @exercise.name = "a" * 256
+    assert_not @exercise.valid?
+    assert_includes @exercise.errors[:name], "は255文字以内で入力してください"
+  end
+
+  test "exercise_typeが必須である" do
+    @exercise.exercise_type = nil
+    assert_not @exercise.valid?
+    assert_includes @exercise.errors[:exercise_type], "を入力してください"
+  end
+
+  test "strengthタイプの場合lateralityが必須である" do
+    @exercise.exercise_type = "strength"
+    @exercise.laterality = nil
+    assert_not @exercise.valid?
+    assert_includes @exercise.errors[:laterality], "を入力してください"
+  end
+
+  test "cardioタイプの場合lateralityは必ずnilである" do
+    @exercise.exercise_type = "cardio"
+    @exercise.laterality = nil
+    assert @exercise.valid?
+  end
+
+  test "cardioタイプでlateralityが設定されている場合は無効である" do
+    @exercise.exercise_type = "cardio"
+    @exercise.laterality = "bilateral"
+    assert_not @exercise.valid?
+    assert_includes @exercise.errors[:laterality], "有酸素運動の場合、実施形態は設定できません"
+  end
+
+  test "memoは任意項目である" do
+    @exercise.memo = nil
+    assert @exercise.valid?
+  end
+
+  test "exercise_typeの有効な値を受け入れる" do
+    valid_exercise_types = %w[strength cardio]
+
+    valid_exercise_types.each do |exercise_type|
+      @exercise.exercise_type = exercise_type
+      if exercise_type == "cardio"
+        @exercise.laterality = nil
+      else
+        @exercise.laterality = "bilateral"
+      end
+      assert @exercise.valid?, "#{exercise_type}は有効な値であるべき"
+    end
+  end
+
+  test "lateralityの有効な値を受け入れる" do
+    valid_lateralities = %w[bilateral unilateral]
+
+    valid_lateralities.each do |laterality|
+      @exercise.laterality = laterality
+      assert @exercise.valid?, "#{laterality}は有効な値であるべき"
+    end
+  end
+
+  test "無効なexercise_typeを拒否する" do
+    assert_raises(ArgumentError) do
+      @exercise.exercise_type = "invalid_type"
+    end
+  end
+
+  test "無効なlateralityを拒否する" do
+    assert_raises(ArgumentError) do
+      @exercise.laterality = "invalid_laterality"
+    end
+  end
+
+  test "両側実施の筋力トレーニング例" do
+    exercise = Exercise.new(
+      name: "スクワット",
+      exercise_type: "strength",
+      laterality: "bilateral"
+    )
+    assert exercise.valid?
+    assert exercise.strength?
+    assert exercise.bilateral?
+  end
+
+  test "片側実施の筋力トレーニング例" do
+    exercise = Exercise.new(
+      name: "ダンベルカール",
+      exercise_type: "strength",
+      laterality: "unilateral"
+    )
+    assert exercise.valid?
+    assert exercise.strength?
+    assert exercise.unilateral?
+  end
+
+  test "有酸素運動の例" do
+    exercise = Exercise.new(
+      name: "ランニング",
+      exercise_type: "cardio"
+    )
+    assert exercise.valid?
+    assert exercise.cardio?
+    assert_nil exercise.laterality
+  end
+end

--- a/test/models/exercise_test.rb
+++ b/test/models/exercise_test.rb
@@ -3,10 +3,10 @@
 # Table name: exercises
 #
 #  id            :bigint           not null, primary key
-#  exercise_type :integer
+#  exercise_type :integer          not null
 #  laterality    :integer
 #  memo          :text(65535)
-#  name          :string(255)
+#  name          :string(255)      not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id           :bigint           not null, primary key
+#  email        :string(255)
+#  firebase_uid :string(255)
+#  image_url    :string(255)
+#  name         :string(255)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_firebase_uid  (firebase_uid) UNIQUE
+#
 require "test_helper"
 
 class UserTest < ActiveSupport::TestCase


### PR DESCRIPTION
## Summary
- Exercise モデルの実装を完了
- enum による運動タイプ（strength/cardio）と実施形態（bilateral/unilateral）の管理
- 適切なバリデーションとテストの実装

## 主な変更点
- `CreateExercises` マイグレーションファイルの作成
- `Exercise` モデルクラスの実装（バリデーション・enum定義）
- 16のテストケース実装（全テスト通過）
- annotaterb によるスキーマ情報の追加
- データベース設計ドキュメントの更新

## Test plan
- [x] すべてのテストが通過することを確認
- [x] マイグレーションが正常に実行されることを確認
- [x] enum 値が正しく設定されることを確認
- [x] バリデーションが適切に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)