### PR TITLE
Exerciseモデルに部位（body_part）属性を追加

### DIFF
--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -3,6 +3,7 @@
 # Table name: exercises
 #
 #  id            :bigint           not null, primary key
+#  body_part     :integer
 #  exercise_type :integer          not null
 #  laterality    :integer
 #  memo          :text(65535)
@@ -12,15 +13,20 @@
 #
 # Indexes
 #
-#  index_exercises_on_exercise_type  (exercise_type)
-#  index_exercises_on_name           (name) UNIQUE
+#  index_exercises_on_body_part                    (body_part)
+#  index_exercises_on_exercise_type                (exercise_type)
+#  index_exercises_on_exercise_type_and_body_part  (exercise_type,body_part)
+#  index_exercises_on_name                         (name) UNIQUE
 #
 class Exercise < ApplicationRecord
   enum :exercise_type, { strength: 0, cardio: 1 }
   enum :laterality, { bilateral: 0, unilateral: 1 }
+  enum :body_part, { legs: 0, back: 1, shoulders: 2, arms: 3, chest: 4 }
 
   validates :name, presence: true, uniqueness: true, length: { maximum: 255 }
   validates :exercise_type, presence: true
   validates :laterality, presence: true, if: :strength?
   validates :laterality, absence: { message: :cardio_cannot_have_laterality }, if: :cardio?
+  validates :body_part, presence: true, if: :strength?
+  validates :body_part, absence: { message: :cardio_cannot_have_body_part }, if: :cardio?
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -24,3 +24,5 @@ ja:
           attributes:
             laterality:
               cardio_cannot_have_laterality: "有酸素運動の場合、実施形態は設定できません"
+            body_part:
+              cardio_cannot_have_body_part: "有酸素運動の場合、部位は設定できません"

--- a/db/migrate/20250908100000_add_body_part_to_exercises.rb
+++ b/db/migrate/20250908100000_add_body_part_to_exercises.rb
@@ -1,0 +1,7 @@
+class AddBodyPartToExercises < ActiveRecord::Migration[8.0]
+  def change
+    add_column :exercises, :body_part, :integer
+    add_index :exercises, :body_part
+    add_index :exercises, [ :exercise_type, :body_part ]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_08_082419) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_08_100000) do
   create_table "exercises", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.string "name", null: false
     t.integer "exercise_type", null: false
@@ -18,6 +18,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_08_082419) do
     t.text "memo"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "body_part"
+    t.index ["body_part"], name: "index_exercises_on_body_part"
+    t.index ["exercise_type", "body_part"], name: "index_exercises_on_exercise_type_and_body_part"
     t.index ["exercise_type"], name: "index_exercises_on_exercise_type"
     t.index ["name"], name: "index_exercises_on_name", unique: true
   end


### PR DESCRIPTION
## Summary
• Exerciseモデルに部位（body_part）属性を新規追加
• 脚・背中・肩・腕・胸の5部位をenumで実装
• 筋力トレーニングでは部位必須、有酸素運動では部位NULL制約を追加
• 部位検索用のインデックス設定（単体・運動タイプとの複合）
• I18n対応のエラーメッセージ実装

## Test plan
- [x] 全5部位（legs, back, shoulders, arms, chest）の有効性確認済み
- [x] strengthタイプでのbody_part必須バリデーション動作確認
- [x] cardioタイプでのbody_part禁止バリデーション動作確認
- [x] 部位enum境界値テスト（invalid値の拒否）確認
- [x] 既存テストとの整合性確認（59 tests, 140 assertions, 0 failures）

## 部位enum仕様
- `legs` (脚): 0
- `back` (背中): 1  
- `shoulders` (肩): 2
- `arms` (腕): 3
- `chest` (胸): 4

## インデックス設計
- `index_exercises_on_body_part` - 部位別検索用
- `index_exercises_on_exercise_type_and_body_part` - 運動タイプ×部位検索用

🤖 Generated with [Claude Code](https://claude.ai/code)