### PR TITLE
WorkoutExerciseモデルの追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,20 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **I18nファイルの活用**: `config/locales/ja.yml`にエラーメッセージを定義し、`errors.add(:field, :error_key)`の形式で使用する
 - **テストの堅牢性**: テストではエラーメッセージの文字列ではなく、`errors.details`を使用してエラーの種類（シンボル）を検証する
 
+### バリデーションエラーのテスト記法
+- **assert_includes を使用**: バリデーションエラーの検証には必ず `assert_includes` と `errors.details` を組み合わせて使用する
+  ```ruby
+  # 基本的な記法
+  assert_includes workout_exercise.errors.details[:workout], { error: :blank }
+  
+  # 値を含む場合
+  assert_includes workout_exercise.errors.details[:order_index], { error: :greater_than_or_equal_to, value: 0, count: 1 }
+  
+  # ユニーク制約違反の場合
+  assert_includes workout_exercise.errors.details[:exercise_id], { error: :taken, value: @exercise.id }
+  ```
+- **文字列での検証は避ける**: `assert_includes workout.errors[:field], "エラーメッセージ"` の形式は使用しない
+
 ### enumの定義とマジックナンバー回避
 - **Rails 7以降のenum定義**: `enum :name, { key: value }` の形式を使用する（第一引数にシンボルを渡す）
   ```ruby

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -22,6 +22,8 @@ class Exercise < ApplicationRecord
   enum :laterality, { bilateral: 0, unilateral: 1 }
   enum :body_part, { legs: 0, back: 1, shoulders: 2, arms: 3, chest: 4 }
 
+  has_many :workout_exercises, dependent: :restrict_with_error
+
   validates :name, presence: true, uniqueness: true, length: { maximum: 255 }
   validates :exercise_type, presence: true
   validates :laterality, presence: true, if: :strength?

--- a/app/models/workout.rb
+++ b/app/models/workout.rb
@@ -21,6 +21,7 @@
 #
 class Workout < ApplicationRecord
   belongs_to :user
+  has_many :workout_exercises, dependent: :destroy
 
   validates :performed_start_at, presence: true
   validates :total_volume, numericality: { greater_than_or_equal_to: 0 }

--- a/app/models/workout_exercise.rb
+++ b/app/models/workout_exercise.rb
@@ -1,0 +1,8 @@
+class WorkoutExercise < ApplicationRecord
+  belongs_to :workout
+  belongs_to :exercise
+
+  validates :order_index, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 1 }
+  validates :total_volume, numericality: { greater_than_or_equal_to: 0 }
+  validates :exercise_id, uniqueness: { scope: :workout_id }
+end

--- a/app/models/workout_exercise.rb
+++ b/app/models/workout_exercise.rb
@@ -1,3 +1,28 @@
+# == Schema Information
+#
+# Table name: workout_exercises
+#
+#  id           :bigint           not null, primary key
+#  notes        :text(65535)
+#  order_index  :integer          not null
+#  total_volume :integer          default(0), not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  exercise_id  :bigint           not null
+#  workout_id   :bigint           not null
+#
+# Indexes
+#
+#  index_workout_exercises_on_exercise_id                 (exercise_id)
+#  index_workout_exercises_on_workout_id                  (workout_id)
+#  index_workout_exercises_on_workout_id_and_exercise_id  (workout_id,exercise_id) UNIQUE
+#  index_workout_exercises_on_workout_id_and_order_index  (workout_id,order_index)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (exercise_id => exercises.id)
+#  fk_rails_...  (workout_id => workouts.id)
+#
 class WorkoutExercise < ApplicationRecord
   belongs_to :workout
   belongs_to :exercise

--- a/db/migrate/20250109_create_workout_exercises.rb
+++ b/db/migrate/20250109_create_workout_exercises.rb
@@ -1,0 +1,16 @@
+class CreateWorkoutExercises < ActiveRecord::Migration[8.0]
+  def change
+    create_table :workout_exercises do |t|
+      t.references :workout, null: false, foreign_key: true
+      t.references :exercise, null: false, foreign_key: { on_delete: :restrict }
+      t.integer :order_index, null: false
+      t.integer :total_volume, default: 0, null: false
+      t.text :notes
+
+      t.timestamps
+    end
+
+    add_index :workout_exercises, [ :workout_id, :exercise_id ], unique: true
+    add_index :workout_exercises, [ :workout_id, :order_index ]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -36,6 +36,20 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_08_100000) do
     t.index ["firebase_uid"], name: "index_users_on_firebase_uid", unique: true
   end
 
+  create_table "workout_exercises", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+    t.bigint "workout_id", null: false
+    t.bigint "exercise_id", null: false
+    t.integer "order_index", null: false
+    t.integer "total_volume", default: 0, null: false
+    t.text "notes"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["exercise_id"], name: "index_workout_exercises_on_exercise_id"
+    t.index ["workout_id", "exercise_id"], name: "index_workout_exercises_on_workout_id_and_exercise_id", unique: true
+    t.index ["workout_id", "order_index"], name: "index_workout_exercises_on_workout_id_and_order_index"
+    t.index ["workout_id"], name: "index_workout_exercises_on_workout_id"
+  end
+
   create_table "workouts", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.datetime "performed_start_at", null: false
@@ -47,5 +61,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_08_100000) do
     t.index ["user_id"], name: "index_workouts_on_user_id"
   end
 
+  add_foreign_key "workout_exercises", "exercises"
+  add_foreign_key "workout_exercises", "workouts"
   add_foreign_key "workouts", "users"
 end

--- a/test/models/workout_exercise_test.rb
+++ b/test/models/workout_exercise_test.rb
@@ -1,0 +1,211 @@
+require "test_helper"
+
+class WorkoutExerciseTest < ActiveSupport::TestCase
+  def setup
+    @user = User.create!(username: "testuser", firebase_uid: "firebase123")
+    @workout = Workout.create!(
+      user: @user,
+      workout_date: Date.today,
+      location: "自宅"
+    )
+    @exercise = Exercise.create!(
+      name: "ベンチプレス",
+      exercise_type: :strength,
+      body_part: :chest
+    )
+  end
+
+  test "有効なworkout_exerciseを作成できる" do
+    workout_exercise = WorkoutExercise.new(
+      workout: @workout,
+      exercise: @exercise,
+      order_index: 1
+    )
+    assert workout_exercise.valid?
+  end
+
+  test "workoutがない場合は無効" do
+    workout_exercise = WorkoutExercise.new(
+      exercise: @exercise,
+      order_index: 1
+    )
+    assert_not workout_exercise.valid?
+    assert_includes workout_exercise.errors.details[:workout], { error: :blank }
+  end
+
+  test "exerciseがない場合は無効" do
+    workout_exercise = WorkoutExercise.new(
+      workout: @workout,
+      order_index: 1
+    )
+    assert_not workout_exercise.valid?
+    assert_includes workout_exercise.errors.details[:exercise], { error: :blank }
+  end
+
+  test "order_indexがない場合は無効" do
+    workout_exercise = WorkoutExercise.new(
+      workout: @workout,
+      exercise: @exercise
+    )
+    assert_not workout_exercise.valid?
+    assert_includes workout_exercise.errors.details[:order_index], { error: :blank }
+  end
+
+  test "order_indexは1以上でなければならない" do
+    workout_exercise = WorkoutExercise.new(
+      workout: @workout,
+      exercise: @exercise,
+      order_index: 0
+    )
+    assert_not workout_exercise.valid?
+    assert_includes workout_exercise.errors.details[:order_index], { error: :greater_than_or_equal_to, value: 0, count: 1 }
+  end
+
+  test "order_indexは整数でなければならない" do
+    workout_exercise = WorkoutExercise.new(
+      workout: @workout,
+      exercise: @exercise,
+      order_index: 1.5
+    )
+    assert_not workout_exercise.valid?
+    assert_includes workout_exercise.errors.details[:order_index], { error: :not_an_integer, value: 1.5 }
+  end
+
+  test "同じworkout内でorder_indexの重複は許可される" do
+    WorkoutExercise.create!(
+      workout: @workout,
+      exercise: @exercise,
+      order_index: 1
+    )
+
+    another_exercise = Exercise.create!(
+      name: "スクワット",
+      exercise_type: :strength,
+      body_part: :legs
+    )
+
+    workout_exercise = WorkoutExercise.new(
+      workout: @workout,
+      exercise: another_exercise,
+      order_index: 1
+    )
+    assert workout_exercise.valid?
+  end
+
+  test "異なるworkoutでは同じexerciseを使用できる" do
+    WorkoutExercise.create!(
+      workout: @workout,
+      exercise: @exercise,
+      order_index: 1
+    )
+
+    another_workout = Workout.create!(
+      user: @user,
+      workout_date: Date.tomorrow,
+      location: "ジム"
+    )
+
+    workout_exercise = WorkoutExercise.new(
+      workout: another_workout,
+      exercise: @exercise,
+      order_index: 1
+    )
+    assert workout_exercise.valid?
+  end
+
+  test "同じworkoutで同じexerciseは一度しか使用できない" do
+    WorkoutExercise.create!(
+      workout: @workout,
+      exercise: @exercise,
+      order_index: 1
+    )
+
+    workout_exercise = WorkoutExercise.new(
+      workout: @workout,
+      exercise: @exercise,
+      order_index: 2
+    )
+    assert_not workout_exercise.valid?
+    assert_includes workout_exercise.errors.details[:exercise_id], { error: :taken, value: @exercise.id }
+  end
+
+  test "削除時の挙動" do
+    workout_exercise = WorkoutExercise.create!(
+      workout: @workout,
+      exercise: @exercise,
+      order_index: 1
+    )
+
+    assert_difference("WorkoutExercise.count", -1) do
+      workout_exercise.destroy
+    end
+  end
+
+  test "workoutが削除されたときに関連するworkout_exerciseも削除される" do
+    WorkoutExercise.create!(
+      workout: @workout,
+      exercise: @exercise,
+      order_index: 1
+    )
+
+    assert_difference("WorkoutExercise.count", -1) do
+      @workout.destroy
+    end
+  end
+
+  test "exerciseが削除されたときにworkout_exerciseの削除は制限される" do
+    WorkoutExercise.create!(
+      workout: @workout,
+      exercise: @exercise,
+      order_index: 1
+    )
+
+    assert_raises(ActiveRecord::DeleteRestrictionError) do
+      @exercise.destroy
+    end
+  end
+
+  test "workout_exercises_countがキャッシュされる" do
+    workout_exercise = WorkoutExercise.create!(
+      workout: @workout,
+      exercise: @exercise,
+      order_index: 1,
+      workout_exercises_count: 0
+    )
+
+    assert_equal 0, workout_exercise.workout_exercises_count
+  end
+
+  test "notesフィールドに長いテキストを保存できる" do
+    long_text = "a" * 1000
+    workout_exercise = WorkoutExercise.new(
+      workout: @workout,
+      exercise: @exercise,
+      order_index: 1,
+      notes: long_text
+    )
+    assert workout_exercise.valid?
+    workout_exercise.save!
+    assert_equal long_text, workout_exercise.reload.notes
+  end
+
+  test "notesフィールドはnullを許可する" do
+    workout_exercise = WorkoutExercise.new(
+      workout: @workout,
+      exercise: @exercise,
+      order_index: 1,
+      notes: nil
+    )
+    assert workout_exercise.valid?
+  end
+
+  test "notesフィールドは空文字列を許可する" do
+    workout_exercise = WorkoutExercise.new(
+      workout: @workout,
+      exercise: @exercise,
+      order_index: 1,
+      notes: ""
+    )
+    assert workout_exercise.valid?
+  end
+end

--- a/test/models/workout_exercise_test.rb
+++ b/test/models/workout_exercise_test.rb
@@ -1,3 +1,28 @@
+# == Schema Information
+#
+# Table name: workout_exercises
+#
+#  id           :bigint           not null, primary key
+#  notes        :text(65535)
+#  order_index  :integer          not null
+#  total_volume :integer          default(0), not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  exercise_id  :bigint           not null
+#  workout_id   :bigint           not null
+#
+# Indexes
+#
+#  index_workout_exercises_on_exercise_id                 (exercise_id)
+#  index_workout_exercises_on_workout_id                  (workout_id)
+#  index_workout_exercises_on_workout_id_and_exercise_id  (workout_id,exercise_id) UNIQUE
+#  index_workout_exercises_on_workout_id_and_order_index  (workout_id,order_index)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (exercise_id => exercises.id)
+#  fk_rails_...  (workout_id => workouts.id)
+#
 require "test_helper"
 
 class WorkoutExerciseTest < ActiveSupport::TestCase

--- a/test/models/workout_exercise_test.rb
+++ b/test/models/workout_exercise_test.rb
@@ -2,16 +2,20 @@ require "test_helper"
 
 class WorkoutExerciseTest < ActiveSupport::TestCase
   def setup
-    @user = User.create!(username: "testuser", firebase_uid: "firebase123")
+    @user = User.create!(
+      name: "testuser",
+      email: "test@example.com",
+      firebase_uid: "firebase123"
+    )
     @workout = Workout.create!(
       user: @user,
-      workout_date: Date.today,
-      location: "自宅"
+      performed_start_at: Time.current
     )
     @exercise = Exercise.create!(
       name: "ベンチプレス",
       exercise_type: :strength,
-      body_part: :chest
+      body_part: :chest,
+      laterality: :bilateral
     )
   end
 
@@ -81,7 +85,8 @@ class WorkoutExerciseTest < ActiveSupport::TestCase
     another_exercise = Exercise.create!(
       name: "スクワット",
       exercise_type: :strength,
-      body_part: :legs
+      body_part: :legs,
+      laterality: :bilateral
     )
 
     workout_exercise = WorkoutExercise.new(
@@ -101,8 +106,7 @@ class WorkoutExerciseTest < ActiveSupport::TestCase
 
     another_workout = Workout.create!(
       user: @user,
-      workout_date: Date.tomorrow,
-      location: "ジム"
+      performed_start_at: Time.current + 1.day
     )
 
     workout_exercise = WorkoutExercise.new(
@@ -160,21 +164,10 @@ class WorkoutExerciseTest < ActiveSupport::TestCase
       order_index: 1
     )
 
-    assert_raises(ActiveRecord::DeleteRestrictionError) do
-      @exercise.destroy
-    end
+    assert_not @exercise.destroy
+    assert @exercise.errors[:base].any?
   end
 
-  test "workout_exercises_countがキャッシュされる" do
-    workout_exercise = WorkoutExercise.create!(
-      workout: @workout,
-      exercise: @exercise,
-      order_index: 1,
-      workout_exercises_count: 0
-    )
-
-    assert_equal 0, workout_exercise.workout_exercises_count
-  end
 
   test "notesフィールドに長いテキストを保存できる" do
     long_text = "a" * 1000


### PR DESCRIPTION
## Summary
- WorkoutとExerciseの中間テーブルであるWorkoutExerciseモデルを実装
- トレーニング記録におけるエクササイズの順序管理と詳細情報の保存機能を追加
- 包括的なテストカバレッジを実装

## 変更内容
### モデルの追加
- `WorkoutExercise`モデル: ワークアウトとエクササイズを関連付ける中間テーブル
  - `order_index`: エクササイズの実行順序（1以上の整数）
  - `total_volume`: 総負荷量（デフォルト0、Setモデル実装後に計算ロジック追加予定）
  - `notes`: メモ欄（任意）

### バリデーション
- `order_index`: 必須、1以上の整数
- `total_volume`: 0以上の数値
- `exercise_id`: workout_idごとに一意（同じワークアウト内で同じエクササイズは1回のみ）

### 関連の設定
- Workoutモデル: `has_many :workout_exercises, dependent: :destroy`
- Exerciseモデル: `has_many :workout_exercises, dependent: :restrict_with_error`

### テスト
- 全てのバリデーションをカバー
- 関連モデル削除時の挙動を検証
- `errors.details`を使用したI18n非依存のエラー検証

## Test plan
- [x] 全てのテストがパスすることを確認
- [x] マイグレーションが正常に実行されることを確認
- [ ] コードレビューの実施

🤖 Generated with [Claude Code](https://claude.ai/code)