### PR TITLE
体重管理機能をドキュメントから削除

### DIFF
--- a/docs/API設計.md
+++ b/docs/API設計.md
@@ -20,7 +20,6 @@
 ### ホーム
 
 - 今日のワークアウトを新規入力・編集・削除ができる。
-- 今日の体重を入力できる。
 - 前回のワークアウトが見られる。1 ページ 10 件。
 - ページングがある（Next/Prev）。
 - ワークアウトを検索ができる。
@@ -30,7 +29,6 @@
 
 - 種目別の最大挙上重量を一覧できる。
 - 種目別のトレーニング強度の推移を Chart で見られる。
-- 自分の体重の推移を Chart で見られる。
 
 ### 設定
 
@@ -68,11 +66,6 @@ Rails の単一テーブル継承（STI）を使用：
   - 総負荷量 = Σ(各セットの重量 × レップ数)
   - ダンベル種目の場合: 総負荷量 = Σ(片方の重量 × 2 × レップ数)
   - 片方ずつやる種目の場合: 総負荷量 = Σ(重量 × (左レップ数 + 右レップ数))
-
-### 体重
-
-- 体重はグラム単位で登録
-- 日ごとに登録が可能。
 
 ## ドメインモデル詳細
 
@@ -131,17 +124,6 @@ Rails の単一テーブル継承（STI）を使用：
 | order               | integer  | セット順                                      |
 | created_at          | datetime | 作成日時（UTC）                               |
 | updated_at          | datetime | 更新日時（UTC）                               |
-
-### Weight
-
-| フィールド  | 型       | 説明            |
-| ----------- | -------- | --------------- |
-| id          | integer  | 主キー          |
-| user_id     | integer  | ユーザー ID     |
-| recorded_at | datetime | 記録日時（UTC） |
-| weight      | integer  | 体重（グラム）  |
-| created_at  | datetime | 作成日時（UTC） |
-| updated_at  | datetime | 更新日時（UTC） |
 
 ## API エンドポイント詳細
 
@@ -291,45 +273,6 @@ DELETE /workouts/:id
 
 ```
 
-### 体重
-
-#### 体重履歴取得
-
-```
-
-GET /weights?start_date=2024-01-01&end_date=2024-01-31
-
-````
-
-**レスポンス**
-
-```json
-{
-  "weights": [
-    {
-      "id": 1,
-      "recorded_at": "2024-01-15T08:00:00Z",
-      "weight": 70000
-    }
-  ]
-}
-````
-
-#### 体重登録・更新
-
-```
-POST /weights
-```
-
-**リクエスト**
-
-```json
-{
-  "recorded_at": "2024-01-15T08:00:00Z",
-  "weight": 70000
-}
-```
-
 ### レコード
 
 #### 種目別最大挙上重量
@@ -379,25 +322,6 @@ GET /records/exercise-trends/:exercise_id?start_date=2024-01-01&end_date=2024-01
 }
 ```
 
-#### 体重推移
-
-```
-GET /records/weight-trends?start_date=2024-01-01&end_date=2024-01-31
-```
-
-**レスポンス**
-
-```json
-{
-  "trends": [
-    {
-      "recorded_at": "2024-01-15T08:00:00Z",
-      "weight": 70000
-    }
-  ]
-}
-```
-
 ### 種目マスタ
 
 #### 種目一覧取得
@@ -442,5 +366,5 @@ DELETE /users/me
 - 認証が必要なエンドポイントは Authorization ヘッダーに Bearer トークンを付与
 - 日付形式は ISO 8601 形式（日付：YYYY-MM-DD、日時：YYYY-MM-DDTHH:MM:SSZ）
 - 日時は UTC で保存、レスポンスも UTC
-- 重量・体重はグラム単位の整数
+- 重量はグラム単位の整数
 - ページネーションは page/per_page パラメータで制御

--- a/docs/データベース設計.md
+++ b/docs/データベース設計.md
@@ -5,7 +5,6 @@
 ```mermaid
 erDiagram
     users ||--o{ workouts : "has many"
-    users ||--o{ weights : "has many"
     workouts ||--o{ workout_exercises : "has many"
     workout_exercises }o--|| exercises : "belongs to"
     workout_exercises ||--o{ sets : "has many"
@@ -61,15 +60,6 @@ erDiagram
         integer duration_seconds "実施時間(秒)"
         integer calories "消費カロリー(kcal)"
         integer order "セット順"
-        datetime created_at
-        datetime updated_at
-    }
-
-    weights {
-        bigint id PK
-        bigint user_id FK
-        datetime recorded_at "記録日時"
-        integer weight "体重(g)"
         datetime created_at
         datetime updated_at
     }
@@ -158,17 +148,6 @@ erDiagram
 | created_at          | datetime     | NO   | CURRENT_TIMESTAMP | 作成日時                          |
 | updated_at          | datetime     | NO   | CURRENT_TIMESTAMP | 更新日時                          |
 
-### weights（体重記録）
-
-| カラム名    | 型       | NULL | デフォルト        | 説明         |
-| ----------- | -------- | ---- | ----------------- | ------------ |
-| id          | bigint   | NO   | AUTO_INCREMENT    | 主キー       |
-| user_id     | bigint   | NO   | -                 | ユーザー ID  |
-| recorded_at | datetime | NO   | -                 | 記録日時     |
-| weight      | integer  | NO   | -                 | 体重(グラム) |
-| created_at  | datetime | NO   | CURRENT_TIMESTAMP | 作成日時     |
-| updated_at  | datetime | NO   | CURRENT_TIMESTAMP | 更新日時     |
-
 ## インデックス設計
 
 ### users
@@ -197,24 +176,18 @@ erDiagram
 - `index_sets_on_type` (type)
 - `index_sets_on_workout_exercise_id_and_order` (workout_exercise_id, order) UNIQUE
 
-### weights
-
-- `index_weights_on_user_id` (user_id)
-- `index_weights_on_user_id_and_recorded_at` (user_id, recorded_at)
-
 ## 外部キー制約
 
 - workouts.user_id → users.id (CASCADE DELETE)
 - workout_exercises.workout_id → workouts.id (CASCADE DELETE)
 - workout_exercises.exercise_id → exercises.id (RESTRICT)
 - sets.workout_exercise_id → workout_exercises.id (CASCADE DELETE)
-- weights.user_id → users.id (CASCADE DELETE)
 
 ## データ型の選択理由
 
 ### integer 型の使用
 
-- **重量・体重**: グラム単位で保存することで小数点計算を回避
+- **重量**: グラム単位で保存することで小数点計算を回避
 - **カロリー**: kcal 単位で整数として保存
 - **時間**: 秒単位で保存
 
@@ -247,6 +220,5 @@ erDiagram
 3. workouts
 4. workout_exercises
 5. sets
-6. weights
 
 この順序で外部キー制約のエラーを回避できます。

--- a/docs/実装方針.md
+++ b/docs/実装方針.md
@@ -178,16 +178,6 @@ end
 
 ### 3. シンプルなクラスメソッド
 
-```ruby
-class Weight < ApplicationRecord
-  def self.record_for_date(user, date, weight_value)
-    weight = user.weights.find_or_initialize_by(recorded_at: date.beginning_of_day)
-    weight.weight = weight_value
-    weight.save
-    weight
-  end
-end
-```
 
 ## 避けるべきこと
 


### PR DESCRIPTION
## Summary
- プロジェクト方針変更により、体重管理機能をドキュメントから削除
- 筋力トレーニング記録に特化したシステム設計に更新

## 変更内容

### 削除したドキュメント項目
- **データベース設計**: `weights`テーブル定義とリレーション、インデックス、外部キー制約
- **API設計**: 体重登録・取得・推移のAPIエンドポイント、画面機能要件
- **実装方針**: Weightモデルのクラスメソッド実装例

### 保持した項目
- 筋トレの重量（weight）に関する記述は引き続き保持
- Set モデルの weight フィールドなど、筋力トレーニングに必要な重量データは維持

## 影響範囲
- ドキュメントのみの変更（コード変更なし）
- 体重管理機能の実装は今回のスコープから除外
- 筋力トレーニング記録機能には影響なし

## Test plan
- [x] ドキュメントの整合性確認
- [x] 筋トレ重量関連の記述が適切に保持されていることを確認
- [x] 体重管理に関する記述が完全に削除されていることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)